### PR TITLE
dev

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,6 +58,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Workload install
+        run: dotnet workload restore Aspire
       
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -54,7 +54,7 @@ jobs:
           global-json-file: ./Global.json
 
       - name: Workload install
-        run: dotnet workload restore
+        run: dotnet workload restore Aspire
 
       - name: Restores
         run: dotnet restore

--- a/.github/workflows/dotnetdev.yml
+++ b/.github/workflows/dotnetdev.yml
@@ -54,7 +54,7 @@ jobs:
           global-json-file: ./Global.json
 
       - name: Workload install
-        run: dotnet workload restore
+        run: dotnet workload restore Aspire
 
       - name: Restores
         run: dotnet restore


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to specify the `Aspire` workload during the `dotnet workload restore` step. The most important changes include updates to the `codeql-analysis.yml`, `dotnet.yml`, and `dotnetdev.yml` files.

Workflow updates:

* [`.github/workflows/codeql-analysis.yml`](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188R62-R64): Added the `Aspire` workload to the `dotnet workload restore` step.
* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L57-R57): Modified the `dotnet workload restore` step to include the `Aspire` workload.
* [`.github/workflows/dotnetdev.yml`](diffhunk://#diff-99e66eb609ca2d51b5fd22d0a1b10600082ee239b7885a2591c86efd2f0a5007L57-R57): Updated the `dotnet workload restore` step to specify the `Aspire` workload.