### PR TITLE
Update dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -54,7 +54,7 @@ jobs:
           global-json-file: ./Global.json
 
       - name: Workload install
-        run: dotnet workload restore Aspire
+        run: dotnet workload restore
 
       - name: Restores
         run: dotnet restore


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/dotnet.yml` file. The change removes the specific workload "Aspire" from the `dotnet workload restore` command.

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L57-R57): Modified the `dotnet workload restore` command to restore all workloads instead of just the "Aspire" workload.