### PR TITLE
Update dotnetdev.yml

### DIFF
--- a/.github/workflows/dotnetdev.yml
+++ b/.github/workflows/dotnetdev.yml
@@ -54,7 +54,7 @@ jobs:
           global-json-file: ./Global.json
 
       - name: Workload install
-        run: dotnet workload restore Aspire
+        run: dotnet workload restore
 
       - name: Restores
         run: dotnet restore


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/dotnetdev.yml` file. The change modifies the `Workload install` step to restore all workloads instead of just the `Aspire` workload.

* [`.github/workflows/dotnetdev.yml`](diffhunk://#diff-99e66eb609ca2d51b5fd22d0a1b10600082ee239b7885a2591c86efd2f0a5007L57-R57): Changed the `dotnet workload restore` command to restore all workloads instead of specifying `Aspire`.